### PR TITLE
feat: add basic dynamic routing for sites

### DIFF
--- a/cmd/lytecade/main.go
+++ b/cmd/lytecade/main.go
@@ -5,6 +5,8 @@ import (
 )
 
 func main() {
-    routes.RoutesInit()
+    routes.RouteInit()
+    routes.RouteSites()
+    routes.RouteListen()
 }
 

--- a/internal/pages/pages.go
+++ b/internal/pages/pages.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 )
@@ -39,4 +40,15 @@ func HandleAboutPage(w http.ResponseWriter, r *http.Request) {
 		Description:    "This is the about page for LyteCade.",
 	}
 	renderTemplate(w, "web/templates/about.tmpl", data)
+}
+
+func HandleGamePage(w http.ResponseWriter, r *http.Request, gameName string) {
+	sitePath := filepath.Join("./web/sites", gameName, "index.html")
+	fmt.FPrintf(w, sitePath)
+}
+
+func HandleGameFolder(siteName, originalPath, resourceFolder string) http.Handler {
+	filePrefix := ("/" + siteName + "/" + resourceFolder)
+	fileServer := http.StripPrefix(filePrefix, http.FileServer(http.Dir(filepath.Join(originalPath, resourceFolder))))
+	return fileServer
 }

--- a/internal/pages/pages.go
+++ b/internal/pages/pages.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"path/filepath"
 )
 
 type PageData struct {
@@ -44,7 +45,7 @@ func HandleAboutPage(w http.ResponseWriter, r *http.Request) {
 
 func HandleGamePage(w http.ResponseWriter, r *http.Request, gameName string) {
 	sitePath := filepath.Join("./web/sites", gameName, "index.html")
-	fmt.FPrintf(w, sitePath)
+	fmt.Println("Files for Game:", sitePath)
 }
 
 func HandleGameFolder(siteName, originalPath, resourceFolder string) http.Handler {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -2,18 +2,51 @@ package routes
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"net/http"
 	"github.com/lytecade/lytecade/internal/pages"
+	"path/filepath"
 )
 
-func RoutesInit() {
-	fs := http.FileServer(http.Dir("./web/static"))
-	http.Handle("/static/", http.StripPrefix("/static", fs))
+func RouteInit() {
+	http.Handle("/static/", http.StripPrefix("/static", http.FileServer(http.Dir("./web/static"))))
 	http.HandleFunc("/", pages.HandleHomePage)
 	http.HandleFunc("/about", pages.HandleAboutPage)
+}
+
+func RouteSites() {
+	err := filepath.Walk("./web/sites", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		currentSite := strings.TrimPrefix(path, "./web/sites")
+		if currentSite == "" {
+			return nil
+		}
+		fmt.Println("Run handle func on: ", fmt.Sprintf("/%s", currentSite))
+		http.HandleFunc(fmt.Sprintf("/%s", currentSite), func(w http.ResponseWriter, r *http.Request) {
+			pages.HandleGamePage(w, r, currentSite)
+		})
+		http.Handle("/" + currentSite + "/assets/", pages.HandleGameFolder(currentSite, path, "assets"))
+		http.Handle("/" + currentSite + "/src/", pages.HandleGameFolder(currentSite, path, "src"))
+
+		return nil
+	})
+	if err != nil {
+		fmt.Println("Error registering game server:", err)
+	}
+}
+
+func RouteListen() {
+	fmt.Println("Listening on Port 8080")
 	err := http.ListenAndServe(":8080", nil)
 	if err != nil {
 		fmt.Println("Error starting server:", err)
 	}
 }
+
 


### PR DESCRIPTION
This change adds a basic boilerplate for dynamic routing. The objective for the dynamic routing is to trace a directory list inside /web/sites/ which will then create routes for each static site directory. The intention of this is that each directory will eventually be its own HTML5 game. 