### PR TITLE
feat: configure route getter for template links

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -16,7 +16,7 @@ var (
 func RouteInit() {
 	http.Handle("/static/", http.StripPrefix("/static", http.FileServer(http.Dir("./web/static"))))
 	http.HandleFunc("/",  func(w http.ResponseWriter, r *http.Request) {
-		pages.HandleHomePage(w, r, currentSites)
+		pages.HandleHomePage(w, r, GetRouteSites())
 	})
 	http.HandleFunc("/about", pages.HandleAboutPage)
 }
@@ -60,7 +60,14 @@ func RouteListen() {
 }
 
 func GetRouteSites() []string {
-    return append([]string(nil), currentSites...)
+	var siteNameArray []string
+	for _, path := range currentSites {
+		parts := strings.Split(path, "/")
+		if !contains(siteNameArray, parts[1]) {
+			siteNameArray = append(siteNameArray, parts[1])
+		}
+	}
+    return siteNameArray
 }
 
 func trimMultiplePrefixes(s string, prefixes []string) string {

--- a/web/templates/index.tmpl
+++ b/web/templates/index.tmpl
@@ -3,7 +3,7 @@
 <p>This is the homepage of my website.</p>
 <ul>
     {{range .SiteList}}
-        <li>{{.}}</li>
+        <li><a href="{{.}}">{{.}}</a></li>
     {{end}}
 </ul>
 {{end}}


### PR DESCRIPTION
This change updates the route getter for the site names to return a list of the sites from the /web/sites directory. Instead of the paths being returned, the basic site name is returned instead which is then used in an anchor tag. This boilerplate is then used to generate the necessary site names which can be used to access future games hosted in the /web/sites folder. 